### PR TITLE
[BUGFIX] Remove defined height for outerframe

### DIFF
--- a/Resources/Public/CSS/theme.css
+++ b/Resources/Public/CSS/theme.css
@@ -169,10 +169,6 @@
     padding-top:10px;
 }
 
-.tx-yag-gallery-thumb-outerframe {
-	height:200px;
-}
-
 .tx-yag-gallery-thumb-innerframe {
     float:left;
     display:block;


### PR DESCRIPTION
If you have a gallery description the gallery list output is messed up. Tested in Firefox (26), Chrome (32), IE (10 bis 7), Opera (12) und Safari (5.1.7) - alles unter Windows ![2014-02-14_003927](https://f.cloud.github.com/assets/1453345/2166653/0ac628fa-950a-11e3-9cc3-5d9b4181e8ec.jpg)
