### PR TITLE
[BUGFIX] Gallery list throws fatal error #1247602160

### DIFF
--- a/Classes/Extlist/Filter/GalleryFilter.php
+++ b/Classes/Extlist/Filter/GalleryFilter.php
@@ -139,7 +139,7 @@ class Tx_Yag_Extlist_Filter_GalleryFilter extends Tx_PtExtlist_Domain_Model_Filt
 
 		if ($this->hideHidden) {
 			$criteria1 = $criteria;
-			$criteria2 = Tx_PtExtlist_Domain_QueryObject_Criteria::equals('hide', '0');
+			$criteria2 = Tx_PtExtlist_Domain_QueryObject_Criteria::equals('hidden', '0');
 			$criteria = Tx_PtExtlist_Domain_QueryObject_Criteria::andOp($criteria1, $criteria2);
 		}
 


### PR DESCRIPTION
Scenario: Gallery list plugin with one gallery shown. After clicking the link to the gallery I get the fatal error
#1247602160: Unknown column 'tx_yag_domain_model_album.hide' in 'where clause': SELECT COUNT(*) FROM tx_yag_domain_model_album WHERE (tx_yag_domain_model_album.gallery = '1' AND tx_yag_domain_model_album.hide = '0') AND tx_yag_domain_model_album.deleted=0 AND tx_yag_domain_model_album.t3ver_state<=0 AND tx_yag_domain_model_album.pid<>-1 AND tx_yag_domain_model_album.hidden=0 AND (tx_yag_domain_model_album.fe_group='' OR tx_yag_domain_model_album.fe_group IS NULL OR tx_yag_domain_model_album.fe_group='0' OR FIND_IN_SET('0',tx_yag_domain_model_album.fe_group) OR FIND_IN_SET('-1',tx_yag_domain_model_album.fe_group)) AND tx_yag_domain_model_album.sys_language_uid IN (0,-1) AND tx_yag_domain_model_album.pid IN (192)
