### PR TITLE
[BUGFIX] Correct INCLUDE_TYPOSCRIPT format for new parser

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -62,7 +62,7 @@ if (TYPO3_MODE === 'BE')	{
 
 
 	// Add Backend TypoScript
-	t3lib_extMgm::addTypoScript($_EXTKEY,'setup','<INCLUDE_TYPOSCRIPT:source=FILE:EXT:yag/Configuration/TypoScript/Backend/Setup.txt>');
+	t3lib_extMgm::addTypoScript($_EXTKEY,'setup','<INCLUDE_TYPOSCRIPT: source="FILE:EXT:yag/Configuration/TypoScript/Backend/Setup.txt">');
 }
 
 


### PR DESCRIPTION
Since 6.2 the TypoScript parser only accepts one include format
