### PR TITLE
[BUGFIX] Add a FlexForm dummy field to prevent parsing errors

### DIFF
--- a/Configuration/FlexForms/YagDriverFlexForm.xml
+++ b/Configuration/FlexForms/YagDriverFlexForm.xml
@@ -1,11 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
 <T3DataStructure>
-    <meta>
-        <langDisable>1</langDisable>
-    </meta>
-    <ROOT>
-        <type>array</type>
-        <el>
-
-        </el>
-    </ROOT>
+	<meta>
+		<langDisable>1</langDisable>
+	</meta>
+	<ROOT>
+		<type>array</type>
+		<el>
+			<dummy>
+				<config>
+					<type>passthrough</type>
+				</config>
+			</dummy>
+		</el>
+	</ROOT>
 </T3DataStructure>


### PR DESCRIPTION
Without any field an error in the form is shown. I think an empty (not visible) field is better than any error message ;-)
