### PR TITLE
[BUGFIX] Use t3lib_div::mkdir_deep as yag requires deep temp folder

### DIFF
--- a/Classes/Domain/FileSystem/Div.php
+++ b/Classes/Domain/FileSystem/Div.php
@@ -80,7 +80,7 @@ class Tx_Yag_Domain_FileSystem_Div {
 	 */
 	public static function checkDir($directory) {
 		if ( FALSE === (@opendir($directory)) ) {
-			t3lib_div::mkdir( $directory );
+			t3lib_div::mkdir_deep( $directory );
 		}
 		return is_dir($directory);
 	}


### PR DESCRIPTION
If you delete the yag folder in typo3temp it should be able to recreate necessary folders
