### PR TITLE
Update RteViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/TceForms/RteViewHelper.php
+++ b/Classes/ViewHelpers/TceForms/RteViewHelper.php
@@ -157,7 +157,6 @@ class Tx_Yag_ViewHelpers_TceForms_RteViewHelper extends Tx_Fluid_ViewHelpers_For
 	 */
 	public function render() {
 
-		require_once(PATH_t3lib.'class.t3lib_timetrack.php');
 		$GLOBALS['TT'] = new t3lib_timeTrack;
 
 		// ***********************************


### PR DESCRIPTION
From extension smoothmigration:
"Using require_once, include_once, include or require on core files will fail since files have been relocated.
While namespacing all the classes have been restructured, relocated and renamed. Including old files therefore will fail. Since TYPO3 CMS 4.3 there is an autoloader which makes manual requiring superfluous: simply use the needed classes."
