### PR TITLE
[Bugfix] Wrong $MCONF List for Access.

### DIFF
--- a/Classes/Utility/Flexform/AbstractFlexformUtility.php
+++ b/Classes/Utility/Flexform/AbstractFlexformUtility.php
@@ -61,7 +61,7 @@ class Tx_Yag_Utility_Flexform_AbstractFlexformUtility {
 	 */
 	protected function checkBackendAccessRights() {
 		$backendUser = $GLOBALS['BE_USER']; /** @var \TYPO3\CMS\Core\Authentication\BackendUserAuthentication $backendUser */
-		$backendUser->modAccess(array('name' => 'web_YagTxYagM1', 'access' => array('user', 'group')), TRUE);
+		$backendUser->modAccess(array('name' => 'web_YagTxYagM1', 'access' => 'user, group'), TRUE);
 	}
 	
 	


### PR DESCRIPTION
If a Backend User not set as Admin, permission check will be broken. The $MCONF List for Access needs comma separated List not an Array.
