### PR TITLE
Compatibility Typo3 7.3.1

### DIFF
--- a/Classes/Domain/Repository/ItemRepository.php
+++ b/Classes/Domain/Repository/ItemRepository.php
@@ -158,7 +158,8 @@ class Tx_Yag_Domain_Repository_ItemRepository extends Tx_Yag_Domain_Repository_A
 
 		} elseif ($result->count() == 1 && $result->current() !== FALSE) {
 			$object = $result->current();
-			$this->identityMap->registerObject($object, $object->getUid());
+            $session = $this->objectManager->get(\TYPO3\CMS\Extbase\Persistence\Generic\Session::class);
+            $session->registerObject($object, $object->getUid());
 			return $object;
 
 		} else {

--- a/Classes/Domain/Repository/ResolutionFileCacheRepository.php
+++ b/Classes/Domain/Repository/ResolutionFileCacheRepository.php
@@ -98,7 +98,8 @@ class Tx_Yag_Domain_Repository_ResolutionFileCacheRepository extends \TYPO3\CMS\
 
 		if ($result !== NULL && !is_array($result) && $result->current() !== FALSE) {
 			$object = $result->current();
-			$this->identityMap->registerObject($object, $object->getUid());
+            $session = $this->objectManager->get(\TYPO3\CMS\Extbase\Persistence\Generic\Session::class);
+			$session->registerObject($object, $object->getUid());
 		}
 
 		return $object;

--- a/Configuration/FlexForms/Flexform.xml
+++ b/Configuration/FlexForms/Flexform.xml
@@ -154,8 +154,7 @@
                         <TCEforms>
                             <label></label>
                             <config>
-                                <type>select</type>
-                                <form_type>user</form_type>
+                                <type>user</type>
                                 <userFunc>user_Tx_Yag_Utility_Flexform_RecordSelector->renderSelectedAlbum</userFunc>
                             </config>
                         </TCEforms>


### PR DESCRIPTION
Remove deprecated method-calls for Typo3 7.3.1. Fix in Flexform. Resolves #40 