### PR TITLE
[BUGFIX] use namespaced class names for usage without compatiblity6 extension

### DIFF
--- a/Configuration/TypoScript/BaseConfig/Framework.ts
+++ b/Configuration/TypoScript/BaseConfig/Framework.ts
@@ -16,7 +16,7 @@ config.tx_extbase {
         enableAutomaticCacheClearing = 1
         updateReferenceIndex = 0
         classes {
-            Tx_Extbase_Domain_Model_FrontendUser {
+            TYPO3\CMS\Extbase\Domain\Model\FrontendUser {
                 mapping {
                     tableName = fe_users
                     recordType >
@@ -25,7 +25,7 @@ config.tx_extbase {
                     }
                 }
             }
-            Tx_Extbase_Domain_Model_FrontendUserGroup {
+            TYPO3\CMS\Extbase\Domain\Model\FrontendUserGroup {
                 mapping {
                     tableName = fe_groups
                     recordType >


### PR DESCRIPTION
If mapping is done without namespaces, this leads to the error as describes in #63 on TYPO3 7.6