### PR TITLE
Missing comma in ext_tables.sql

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -112,4 +112,14 @@ $TCA['tt_content']['types']['list']['subtypes_addlist'][$_EXTKEY . '_pi1'] = 'pi
 
 // Register yag for 'contains plugin' in sysfolders
 $TCA['pages']['columns']['module']['config']['items'][] = ['LLL:EXT:yag/Resources/Private/Language/locallang.xlf:tx_yag_general.yag', 'yag', 'i/ext_icon.png'];
-\TYPO3\CMS\Backend\Sprite\SpriteManager::addTcaTypeIcon('pages', 'contains-yag', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('yag') . 'ext_icon.gif');
+if (class_exists(\TYPO3\CMS\Backend\Sprite\SpriteManager::class)) {
+  \TYPO3\CMS\Backend\Sprite\SpriteManager::addTcaTypeIcon('pages', 'contains-yag', \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('yag') . 'ext_icon.gif');
+} else {
+  /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+  $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+  $iconRegistry->registerIcon(
+    'apps-pagetree-folder-contains-yag',
+    \TYPO3\CMS\Core\Imaging\IconProvider\BitmapIconProvider::class,
+    ['source' => 'EXT:yag/ext_icon.gif']
+  );
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE tx_yag_domain_model_album (
 	galleries int(11) unsigned DEFAULT '0' NOT NULL,
 	thumb int(11) unsigned DEFAULT '0' NOT NULL,
 	date int(11) unsigned DEFAULT '0' NOT NULL,
-	rating float default '0'
+	rating float default '0',
 	fe_user_uid int(11) unsigned DEFAULT '0' NOT NULL,
 	fe_group_uid int(11) unsigned DEFAULT '0' NOT NULL,
 	sorting int(11) unsigned DEFAULT '0' NOT NULL,
@@ -101,7 +101,7 @@ CREATE TABLE tx_yag_domain_model_item (
 	height int(11) DEFAULT '0' NOT NULL,
 	filesize int(11) DEFAULT '0' NOT NULL,
 	item_meta int(11) DEFAULT '0' NOT NULL,
-	rating float default '0'
+	rating float default '0',
 	link text,
 
 	sorting int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Add missing comma to ext_tables.sql.
Requiered for the update to typo3 8.7